### PR TITLE
Fix team member addition logic

### DIFF
--- a/Mas_Project/Data/DataSeeder.cs
+++ b/Mas_Project/Data/DataSeeder.cs
@@ -63,9 +63,9 @@ public static class DataSeeder
             await context.SaveChangesAsync();
 
             // Create a team using the manager (valid by domain rules)
-            var team = await teamService.CreateTeamAsync(2, member1.UserID);
-            await teamService.AddMemberToTeamAsync(team.TeamID, manager.UserID);
-            await teamService.AddMemberToTeamAsync(team.TeamID, member1.UserID);
+            var team = await teamService.CreateTeamAsync(2, manager.UserID);
+            await teamService.AddMemberToTeamAsync(team.TeamID, manager.UserID, manager.UserID);
+            await teamService.AddMemberToTeamAsync(team.TeamID, manager.UserID, member1.UserID);
 
             // Create a quest
             var quest = new Quest(

--- a/Mas_Project/Services/TeamService.cs
+++ b/Mas_Project/Services/TeamService.cs
@@ -42,21 +42,17 @@ public class TeamService
         return team;
     }
 
-    public async Task AddMemberToTeamAsync(Guid teamId, Guid memberId)
+    public async Task AddMemberToTeamAsync(Guid teamId, Guid managerId, Guid memberId)
     {
-        var manager = await _memberRepo.GetByIdAsync(memberId);
+        var manager = await _memberRepo.GetByIdAsync(managerId);
+        var member = await _memberRepo.GetByIdAsync(memberId);
+        var team = await _teamRepo.GetByIdAsync(teamId);
 
-        if (manager == null)
-            throw new ArgumentException("Member not found.");
+        if (manager == null || member == null || team == null)
+            throw new ArgumentException("Team or member not found.");
 
         if (manager.MemberRole != MemberRole.GuildManager)
-            throw new InvalidOperationException("Only a Guild Manager can create teams.");
-        
-        var team = await _teamRepo.GetByIdAsync(teamId);
-        var member = await _memberRepo.GetByIdAsync(memberId);
-
-        if (team == null || member == null)
-            throw new ArgumentException("Team or member not found.");
+            throw new InvalidOperationException("Only a Guild Manager can add members to teams.");
 
         team.AddMember(member);
         await _teamRepo.UpdateAsync(team);


### PR DESCRIPTION
## Summary
- fix `TeamService.AddMemberToTeamAsync` to accept manager id and member id
- correct seeding logic to use manager permissions when creating and populating a team

## Testing
- `dotnet build Mas_Project.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457c66ee14832da018fb4056529c0b